### PR TITLE
lots of fixes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,7 @@
+Copyright 2023 Prabuddh Mathur
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,3 @@
-# if set, move to $XDG_DATA_HOME/The_Enchiridion, otherwise ~/.local/share/The_Enchiridion
-ifeq ($(XDG_DATA_HOME),)
-    # default value
-    XDG_DATA_HOME := $(HOME)/.local/share
-else
-    # if present, remove trailing slash from XDG_DATA_HOME
-    XDG_DATA_HOME := $(patsubst %/,%,$(XDG_DATA_HOME))
-endif
-
-# move The_Enchiridion directory to XDG_DATA_HOME directory
 install:
-	mv -f The_Enchiridion $(XDG_DATA_HOME)
-	sudo mv -f enchiridion /usr/bin
+	cp -r The_Enchiridion /usr/share/
+	cp enchiridion /usr/bin/

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -29,5 +29,5 @@ package() {
     install -Dm755 enchiridion "$pkgdir/usr/bin/enchiridion"
 
     # If there is a LICENSE file, copy it to the standard directory for licenses
-    install -Dm644 LICENSE "$pkgdir/usr/share/licenses/${pkgname%-git}/LICENSE"
+    install -Dm644 LICENSE "$pkgdir/usr/share/licenses/${pkgname%}/LICENSE"
 }

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,33 @@
+# Maintainer: Prabuddh Mathur <prabuddhmathur2002@gmail.com>
+
+pkgname=enchiridion-robin-homer-git
+pkgver=1.0.r17.0a11c03
+pkgrel=1
+pkgdesc="A script to speak a random or specific verse of The Enchiridion of Epictetus narrated by Robin Homer of Vox Stoica on Youtube."
+arch=('x86_64' 'i686')
+url="https://github.com/PrabuddhMathur/enchiridion-robin-homer-git.git"
+license=('MIT')
+depends=('ffmpeg' 'git')
+makedepends=()
+provides=("the_enchiridion")
+source=("git+$url")
+md5sums=('SKIP')
+
+pkgver() {
+    cd "${pkgname}"
+    printf "1.0.r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
+
+package() {
+    cd "$pkgname"
+
+    # Move The_Enchiridion directory to /usr/share/The_Enchiridion
+    install -d "$pkgdir/usr/share/The_Enchiridion"
+    cp -r The_Enchiridion/* "$pkgdir/usr/share/The_Enchiridion"
+
+    # Move enchiridion script to /usr/bin
+    install -Dm755 enchiridion "$pkgdir/usr/bin/enchiridion"
+
+    # If there is a LICENSE file, copy it to the standard directory for licenses
+    install -Dm644 LICENSE "$pkgdir/usr/share/licenses/${pkgname%-git}/LICENSE"
+}

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Prabuddh Mathur <prabuddhmathur2002@gmail.com>
 
 pkgname=enchiridion-robin-homer-git
-pkgver=1.0.r17.0a11c03
+pkgver=1.0.r00.0000000
 pkgrel=1
 pkgdesc="A script to speak a random or specific verse of The Enchiridion of Epictetus narrated by Robin Homer of Vox Stoica on Youtube."
 arch=('x86_64' 'i686')

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Step 1: Clone the git repository with `git clone https://github.com/PrabuddhMath
 
 Step 2: `cd enchiridion-robin-homer-git`
 
-Step 3: `make install` to install it (installs to /usr/bin & ~/.local/share/The\_Enchiridion)
+Step 3: `make install` to install it (installs to /usr/bin & /usr/share)
 
 ## Install via AUR
 
@@ -25,7 +25,7 @@ Step 3: `makepkg -si`
 
 ## Usage
 
-`enchiridion -p`: To randomly play any chapter of The Enchiridion.
+`enchiridion -p`: To randomly play any chapter of The Enchiridion; this is the default option if no argument is passed.
 
 `enchiridion -p <number>`: To play specific chapters of The Enchiridion. Range between 1 to 53.
 

--- a/enchiridion
+++ b/enchiridion
@@ -1,15 +1,12 @@
 #!/bin/bash
 
-# use XDG_DATA_HOME if set, otherwise default to ~/.local/share
-if [ -n "$XDG_DATA_HOME" ]; then
-	# if present, remove a trailing slash from XDG_DATA_HOME
-	XDG_DATA_HOME=$(echo "$XDG_DATA_HOME" | sed 's:/*$::')
-	audio_folder="$XDG_DATA_HOME/The_Enchiridion/"
-else
-	audio_folder="$HOME/.local/share/The_Enchiridion/"
-fi
+audio_folder="/usr/share/The_Enchiridion"
 
 text_file="$audio_folder/enchiridion.txt"
+
+if [ $# -eq 0 ]; then
+  set -- -p
+fi
 
 while getopts "spr" options; do
 	case $options in
@@ -30,7 +27,7 @@ while getopts "spr" options; do
 
 		case ${num} in
 		[1-9] | 1[0-9] | 2[0-9] | 3[0-9] | 4[0-9] | 5[0-3])
-			file=${audio_folder}${num}.mp3
+			file="${audio_folder}/${num}.mp3"
 			pkill ffplay
 			ffplay -nodisp -autoexit ${file} >/dev/null 2>&1 &
 			sed -ne "/^${num}\./,/^$(($num + 1))/p" ${text_file} | sed -e "/$(($num + 1))/d"


### PR DESCRIPTION
hello again!

i've performed several fixes and bundled them together into a single PR:

- include MIT license + install into correct location (/usr/share/licenses/...)
- install data (mp3s) to the standard location, /usr/share, rather than working with xdg_data_home
- fix Makepkg so it no longer uses sudo
- include PKGBUILD in git repo + fix it up. no longer relies on Makepkg and instead follows standard PKGBUILD guidelines to the best of my knowledge
- update readme to reflect these changes

also i'm still having some trouble wrapping my head around the pkgver variable but my understanding is that it is completely safe and sometimes preferred to use a "placeholder" value like 1.0.r00.[...] since it will ultimately be "overwritten" by the pkgver() function anyways.

lastly this is sort-of just an FYI but i've noticed that generally on the AUR, packages are only named with a -git suffix because they install from the newest commits to the git repository, rather than being updated upon version releases, and many of the samples online and documentation reflect this fact. however, this git repo literally has -git in its suffix. if we're being super technical, i think that your AUR package should actually be named enchiridion-robin-homer-git-git for that reason (or you could instead rename the github repo, which would be less funny)

anyways, i'm not actually suggesting that you rename the package or rename the repo; i think as a small hobby package it's fine as-is. i'm just bringing it to your attention because you'll notice that many sample PKGBUILDs explicitly strip the suffix out when working with the repo, which you obviously can't do since your repo has the suffix in its name. this created confusion for me so i'm trying to spare you from that same confusion if you end up deciding to submit more stuff to the AUR!

i'm sure all of these paragraphs are more than you bargained for but hey, i hope i didn't introduce any new bugs and i hope you're doing well!

corbin